### PR TITLE
added feature: select text in editor to create a project's todo

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 			},
 			{
 				"command": "code-todos.addtodo",
-				"title": "add todo"
+				"title": "+ todo"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:code-todos.test",
-		"onCommand:code-todos.todosView"
+		"onCommand:code-todos.todosView",
+		"onCommand:code-todos.addtodo"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
 		"commands": [
 			{
-				"command": "code-todos.test",
-				"title": "test"
-			},
-			{
 				"command": "code-todos.todosView",
 				"title": "see todos"
+			},
+			{
+				"command": "code-todos.addtodo",
+				"title": "add todo"
 			}
 		]
 	},

--- a/src/apiHandlers.ts
+++ b/src/apiHandlers.ts
@@ -12,10 +12,24 @@ export function fetchData(panel: any) {
     });
 }
 
+export async function fetchUserProjectNames() : any{
+  let usersProjects;
+  await axios.get(`http://localhost:3001/api/projects/get/${PLACE_HOLDER}`)
+    .then((response) => {
+      // create & return an array of just the names of a user's projects
+      const usersProjectsData = response.data.projects;
+      usersProjects = usersProjectsData.map((project: any) => project.projectName);
+    })
+    .catch((err) => {
+      console.error('error fetching user project names', err);
+    });
+  return usersProjects;
+}
+
 export function handleDbPost(type: string, username: string, projectName: string, todo: string | null, panel: any) {
   axios.post('http://localhost:3001/api/projects/post', {
     type,
-    username, // hard coded username for now
+    username, // hard coded
     projectName,
     todo
   })
@@ -47,7 +61,7 @@ export function handleDbDelete(type: string, username: string, projectName: stri
 export function handleTodoCompletionToggle(type: string, username: string, projectName: string, todo: string, panel: any) {
   axios.put('http://localhost:3001/api/projects/put', {
     type,
-    username,
+    username, // hardcoded
     projectName,
     todo,
   })

--- a/src/apiHandlers.ts
+++ b/src/apiHandlers.ts
@@ -1,6 +1,18 @@
 import axios from 'axios';
+const PLACE_HOLDER = 'jon doe';
 
-export function handleDbPost(type: string, username: string, projectName: string, todo: string | null, dataFetchCB: any) {
+export function fetchData(panel: any) {
+  axios.get(`http://localhost:3001/api/projects/get/${PLACE_HOLDER}`)
+    .then(async (response) => {
+      const userData = response.data;
+      panel.webview.postMessage({ command: 'sendingData', responseData: userData }); // whole obj = event.data;
+    })
+    .catch((err) => {
+      console.error('error fetching user data', err);
+    });
+}
+
+export function handleDbPost(type: string, username: string, projectName: string, todo: string | null, panel: any) {
   axios.post('http://localhost:3001/api/projects/post', {
     type,
     username, // hard coded username for now
@@ -8,14 +20,14 @@ export function handleDbPost(type: string, username: string, projectName: string
     todo
   })
   .then(() => {
-    dataFetchCB();
+    fetchData(panel);
   })
   .catch((err) => {
     console.error('error posting new data to db', err);
   });
 }
 
-export function handleDbDelete(type: string, username: string, projectName: string, todo: string | null, dataFetchCB: any) {
+export function handleDbDelete(type: string, username: string, projectName: string, todo: string | null, panel: any) {
   axios.delete('http://localhost:3001/api/projects/delete', {
     params: {
       type,
@@ -25,14 +37,14 @@ export function handleDbDelete(type: string, username: string, projectName: stri
     }
   })
   .then(() => {
-    dataFetchCB();
+    fetchData(panel);
   })
   .catch((err) => {
     console.error('error deleting data from db', err);
   });
 }
 
-export function handleTodoCompletionToggle(type: string, username: string, projectName: string, todo: string, dataFetchCB: any) {
+export function handleTodoCompletionToggle(type: string, username: string, projectName: string, todo: string, panel: any) {
   axios.put('http://localhost:3001/api/projects/put', {
     type,
     username,
@@ -40,7 +52,7 @@ export function handleTodoCompletionToggle(type: string, username: string, proje
     todo,
   })
     .then(() => {
-      dataFetchCB();
+      fetchData(panel);
     })
     .catch((err) => {
       console.error('error toggling todo\'s completion state', err);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,21 +102,31 @@ export function activate(context: vscode.ExtensionContext) {
       quickPick.items = userProjectNames.map((label: string) => ({ label }));
       quickPick.onDidChangeSelection(([item]) => {
         if (item) {
-          vscode.window.showInformationMessage(item.label); // item.label is the selected one
+
+          // panel.webview.postMessage({
+          //   command: 'new todo via selection',
+          //   todo: selectedText,
+          //   projectName: item.label, // the selected item
+          // });
+          
+          async function fetchData2() {
+            await axios.get(`http://localhost:3001/api/projects/get/${PLACE_HOLDER}`)
+              .then(async (response) => {
+                const userData = response.data;
+                await panel.webview.postMessage({ command: 'sendingData', responseData: userData }); // whole obj = event.data;
+              })
+              .catch((err) => {
+                console.error('error fetching user data', err);
+              });
+          }
+          handleDbPost('todo', PLACE_HOLDER, item.label, selectedText, fetchData2);
           // hide quickpicker after selection
           quickPick.dispose();
         }
       });
-      // hide quickpicker on quickpicker close without a selection
+      // hide quickpicker if closed without a selection
       quickPick.onDidHide(() => quickPick.dispose());
       quickPick.show();
-
-      panel.webview.postMessage({
-        command: 'new todo via selection',
-        todo: selectedText,
-        project: selectedProject,
-      });
-
     })
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,9 +3,8 @@
 // **logs here show up in the debug console**
 import * as vscode from 'vscode';
 import * as path from 'path';
-import axios from 'axios';
 import { getWebviewContent } from './webviewContent';
-import { fetchData, handleDbPost, handleDbDelete, handleTodoCompletionToggle } from './apiHandlers';
+import { fetchData, fetchUserProjectNames, handleDbPost, handleDbDelete, handleTodoCompletionToggle } from './apiHandlers';
 
 const PLACE_HOLDER = 'jon doe';
 
@@ -33,6 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('code-todos.todosView', async () => {
       console.log('=== EXTENSION IS LIVE ===');
 
+      // fetch data and display to webview
       await fetchData(panel);
 
       // Handle messages from the webview;
@@ -77,15 +77,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
       const selectedText = activeTextEditor.document.getText(activeTextEditor.selection);
 
-      let userProjectNames: string[];
-      await axios.get(`http://localhost:3001/api/projects/get/${PLACE_HOLDER}`)
-        .then(async (response) => {
-          const userProjects = response.data.projects;
-          userProjectNames = userProjects.map((project: any) => project.projectName);
-        })
-        .catch((err) => {
-          console.error('error fetching user project names', err);
-        });
+      const userProjectNames = await fetchUserProjectNames(); // used for the quickpick
 
       const quickPick = vscode.window.createQuickPick();
       quickPick.items = userProjectNames.map((label: string) => ({ label }));
@@ -103,5 +95,5 @@ export function activate(context: vscode.ExtensionContext) {
   );
 }
 
-// this method is called when your extension is deactivated
+// this method is called when the extension is deactivated
 export function deactivate() {}

--- a/src/webview/methods.js
+++ b/src/webview/methods.js
@@ -139,6 +139,11 @@
   window.addEventListener('message', (event) => {
     const message = event.data; // The json data that the extension sent
     switch (message.command) {
+      case 'new todo via selection':
+        console.log(message.text);
+        // post to database and refresh
+        break;
+
       case 'sendingData':
         // how to post an alert to the webview:
         // vscode.postMessage({

--- a/src/webview/methods.js
+++ b/src/webview/methods.js
@@ -142,11 +142,6 @@
   window.addEventListener('message', (event) => {
     const message = event.data; // The json data that the extension sent
     switch (message.command) {
-      case 'new todo via selection':
-        console.log(message.todo, message.projectName);
-        // post to database and refresh
-        break;
-
       case 'sendingData':
         // how to post an alert to the webview:
         // vscode.postMessage({

--- a/src/webview/methods.js
+++ b/src/webview/methods.js
@@ -1,5 +1,8 @@
 // This script will be run within the webview itself
 // It cannot access the main VS Code APIs directly.
+/**
+ * logs here show up in the????
+ */
 (function () {
   const vscode = acquireVsCodeApi();
   // const oldState = vscode.getState();
@@ -140,7 +143,7 @@
     const message = event.data; // The json data that the extension sent
     switch (message.command) {
       case 'new todo via selection':
-        console.log(message.text);
+        console.log(message.todo, message.projectName);
         // post to database and refresh
         break;
 


### PR DESCRIPTION
- added vscode "+ todo" command
- select text in editor -> command+shift+P -> "+ todo" -> select which project from dropdown
- refactored extension.ts by pulling out all api calling functionality and moving it to apiHandlers.ts
- various linter and code cleaning edits made along the way